### PR TITLE
Fix calling 'plan' twice

### DIFF
--- a/t/33-specify-kqueue.t
+++ b/t/33-specify-kqueue.t
@@ -1,4 +1,4 @@
-use Test::More tests => 9;
+use Test::More;
 
 use strict;
 use warnings;
@@ -11,8 +11,11 @@ use TestSupport qw(create_test_files delete_test_files move_test_files $dir);
 use AnyEvent::Filesys::Notify;
 use AnyEvent::Impl::Perl;
 
-plan skip_all => 'Test only on Mac with IO::KQueue'
-  unless $^O eq 'darwin' and eval { require IO::KQueue; 1; };
+unless ($^O eq 'darwin' and eval { require IO::KQueue; 1; }) {
+    plan skip_all => 'Test only on Mac with IO::KQueue'
+} else {
+    plan tests => 9;
+}
 
 TODO: { todo_skip 'IO::KQueue is not working on Mac yet', 9;
 


### PR DESCRIPTION
`plan` is called twice on not Mac such as Linux.
I got following error message on my Linux machine.

```
% prove t/33-specify-kqueue.t
t/33-specify-kqueue.t .. 
1..9
You tried to plan twice at t/33-specify-kqueue.t line 15.
# Looks like your test exited with 255 before it could output anything.
Dubious, test returned 255 (wstat 65280, 0xff00)
Failed 9/9 subtests 

Test Summary Report
-------------------
t/33-specify-kqueue.t (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
  Parse errors: Bad plan.  You planned 9 tests but ran 0.
Files=1, Tests=0,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.22 cusr  0.02 csys =  0.27 CPU)
Result: FAIL
```

I fix that `plan` is called only once.
Please review this patch.
