### PR TITLE
Fix KQueue will cause CPU 100%

### DIFF
--- a/lib/AnyEvent/Filesys/Notify/Role/KQueue.pm
+++ b/lib/AnyEvent/Filesys/Notify/Role/KQueue.pm
@@ -20,7 +20,7 @@ sub _init {
         $kqueue->EV_SET(
             fileno($fh),
             EVFILT_VNODE,
-            EV_ADD | EV_ENABLE,
+            EV_ADD | EV_ENABLE | EV_CLEAR,
             NOTE_DELETE | NOTE_WRITE | NOTE_EXTEND | NOTE_ATTRIB |
             NOTE_LINK | NOTE_RENAME | NOTE_REVOKE,
         );


### PR DESCRIPTION
Dear mvgrimes,
I found that AnyEvent-Filesys-Notify will causes CPU high loading.

I added EV_RESET flag so this problem won't be happened.

Thanks.
