### PR TITLE
Add flag to skip subdirs

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,6 +1,6 @@
 Wishlist of things to add to this module:
 
-o Add flag to avoid recursing on fs scan (RT#104714)
+x Add flag to avoid recursing on fs scan (RT#104714)
 o Make Linux::Inotify2 flags an attribute that can be changed by user
 o Monitor individual files
 o Filter/exclued files in a dir

--- a/lib/AnyEvent/Filesys/Notify.pm
+++ b/lib/AnyEvent/Filesys/Notify.pm
@@ -23,6 +23,7 @@ has no_external  => ( is => 'ro', isa => 'Bool',          default  => 0 );
 has backend      => ( is => 'ro', isa => 'Str',           default  => '' );
 has filter       => ( is => 'rw', isa => 'RegexpRef|CodeRef' );
 has parse_events => ( is => 'rw', isa => 'Bool',          default  => 0 );
+has skip_subdirs => ( is => 'ro', isa => 'Bool',          default  => 0 );
 has _fs_monitor  => ( is => 'rw', );
 has _old_fs => ( is => 'rw', isa => 'HashRef' );
 has _watcher => ( is => 'rw', );
@@ -91,6 +92,9 @@ sub _scan_fs {
     my $fs_stats = {};
 
     my $rule = Path::Iterator::Rule->new;
+    $rule->skip_subdirs(qr/./)
+        if (ref $self) =~ /^AnyEvent::Filesys::Notify/
+        && $self->skip_subdirs;
     my $next = $rule->iter(@paths);
     while ( my $file = $next->() ) {
         my $stat = $self->_stat($file)
@@ -356,6 +360,13 @@ generate an additional 'modified' event when a file changes (once when opened
 for write, and once when modified).
 
 =back
+
+=item skip_subdirs
+
+    skip_subdirs => 1,
+
+Skips subdirectories and anything in them while building a list of files/dirs
+to watch. Optional.
 
 =head1 WATCHER IMPLEMENTATIONS
 

--- a/t/35-skip_subdirs.t
+++ b/t/35-skip_subdirs.t
@@ -1,0 +1,80 @@
+use Test::More tests => 11;
+
+use strict;
+use warnings;
+use File::Spec;
+use lib 't/lib';
+$|++;
+
+use TestSupport qw(create_test_files delete_test_files move_test_files
+  modify_attrs_on_test_files $dir received_events receive_event);
+
+use AnyEvent::Filesys::Notify;
+use AnyEvent::Impl::Perl;
+
+create_test_files(qw(one/1));
+create_test_files(qw(two/1));
+create_test_files(qw(one/sub/1));
+## ls: one/1 one/sub/1 two/1
+
+my $n = AnyEvent::Filesys::Notify->new(
+    dirs   => [ map { File::Spec->catfile( $dir, $_ ) } qw(one two) ],
+    cb     => sub   { receive_event(@_) },
+    skip_subdirs => 1,
+);
+isa_ok( $n, 'AnyEvent::Filesys::Notify' );
+
+SKIP: {
+    skip "not sure which os we are on", 1
+      unless $^O =~ /linux|darwin|bsd/;
+    ok( $n->does('AnyEvent::Filesys::Notify::Role::Inotify2'),
+        '... with the linux role' )
+      if $^O eq 'linux';
+    ok( $n->does('AnyEvent::Filesys::Notify::Role::FSEvents'),
+        '... with the mac role' )
+      if $^O eq 'darwin';
+    ok( $n->does('AnyEvent::Filesys::Notify::Role::KQueue'),
+        '... with the bsd role' )
+      if $^O =~ /bsd/;
+}
+
+diag "This might take a few seconds to run...";
+
+# ls: one/1 +one/2 one/sub/1 two/1
+received_events( sub { create_test_files(qw(one/2)) },
+    'create a file', qw(created) );
+
+# ls: one/1 ~one/2 one/sub/1 two/1
+received_events( sub { create_test_files(qw(one/2)) },
+    'modify a file', qw(modified) );
+
+# ls: one/1 -one/2 one/sub/1 two/1
+received_events( sub { delete_test_files(qw(one/2)) },
+    'delete a file', qw(deleted) );
+
+# ls: one/1 one/sub/1 +one/sub/2 two/1
+received_events( sub { create_test_files(qw(one/sub/2)) },
+    'create a file in subdir', qw() );
+
+# ls: one/1 one/sub/1 ~one/sub/2 two/1
+received_events( sub { create_test_files(qw(one/sub/2)) },
+    'modify a file in subdir', qw() );
+
+# ls: one/1 one/sub/1 -one/sub/2 two/1
+received_events( sub { delete_test_files(qw(one/sub/2)) },
+    'delete a file in subdir', qw() );
+
+SKIP: {
+    skip "skip attr mods on Win32", 1 if $^O eq 'MSWin32';
+
+    # ls: one/1 one/sub/1 ~two/1
+    received_events( sub { modify_attrs_on_test_files(qw(two/1)) },
+        'modify attributes', qw(modified) );
+
+    # ls: one/1 ~one/sub/1 two/1
+    received_events( sub { modify_attrs_on_test_files(qw(one/sub/1)) },
+        'modify attributes in a subdir', qw() );
+}
+
+ok( 1, '... arrived' );
+


### PR DESCRIPTION
Hi! Thanks for maintaining AnyEvent::Filesys::Notify! It was my assignment for CPAN Pull Request Challenge - October 2017.

I was going through your TODO list, and found out you wanted to add a flag to skip recursion. I implemented one, and added some tests to make sure it's running fine. I hope you find it useful! Let me know if you want me to update anything.

This PR will probably let us close RT ticket at https://rt.cpan.org/Public/Bug/Display.html?id=104714.

Thanks!

\#cpan-prc \#hacktoberfest